### PR TITLE
Add sort feature

### DIFF
--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -22,7 +22,7 @@ public class Duke {
 
         Hashtable<String, Consumer<String>> table = new Hashtable<>();
 
-        table.put("list", (x) -> Ui.printTasks(taskBank.getTasks()));
+        table.put("list", (x) -> Ui.printTasks(taskBank.getTasks(x)));
         table.put("event", (x) -> taskBank.addTask(x, Event::create));
         table.put("deadline", (x) -> taskBank.addTask(x, Deadline::create));
         table.put("todo", (x) -> taskBank.addTask(x, ToDo::create));

--- a/src/main/java/duke/Storage.java
+++ b/src/main/java/duke/Storage.java
@@ -58,13 +58,13 @@ public class Storage {
 
             return (ArrayList<Task>) (inputStream.readObject());
         } catch (FileNotFoundException e) {
-            System.out.println("WARNING: Task.Task list's save file missing.\n"
+            System.out.println("WARNING: Task list's save file missing.\n"
                     + e.getMessage());
         } catch (IOException e) {
-            System.out.println("WARNING: Task.Task List not properly retrieved.\n"
+            System.out.println("WARNING: Task List not properly retrieved.\n"
                     + e.getMessage());
         } catch (ClassNotFoundException e) {
-            System.out.println("WARNING: Missing Class ArrayList<Task.Task>.\n"
+            System.out.println("WARNING: Missing Class ArrayList<Task>.\n"
                     + e.getMessage());
         }
 
@@ -84,9 +84,9 @@ public class Storage {
             outputStream.writeObject(taskList);
             outputStream.close();
         } catch (FileNotFoundException e) {
-            System.out.println("WARNING: Task.Task list's save file missing.\n" + e.getMessage());
+            System.out.println("WARNING: Task list's save file missing.\n" + e.getMessage());
         } catch (IOException e) {
-            System.out.println("WARNING: Task.Task List not properly saved.\n" + e.getMessage());
+            System.out.println("WARNING: Task List not properly saved.\n" + e.getMessage());
         }
     }
 

--- a/src/main/java/duke/TaskBank.java
+++ b/src/main/java/duke/TaskBank.java
@@ -1,11 +1,15 @@
 package duke;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.function.Function;
 
 import duke.task.Task;
 import duke.util.DukeException;
 import duke.util.Utility;
+import duke.util.sort.DoneSorter;
+import duke.util.sort.NameSorter;
+import duke.util.sort.TimeSorter;
 
 /**
  * Stores and manages the user's list of tasks.
@@ -87,7 +91,7 @@ public class TaskBank {
     public ArrayList<Task> searchTasks(String query) {
         query = query.split(" ", 2)[1].trim();
 
-        ArrayList matchingTasks = new ArrayList<Task>();
+        ArrayList<Task> matchingTasks = new ArrayList<>();
 
         for (Task t : this.taskList) {
             if (t.getDescription().contains(query)) {
@@ -98,11 +102,34 @@ public class TaskBank {
         return matchingTasks;
     }
 
+    private ArrayList<Task> sortTasks(Comparator<Task> cmp) {
+        ArrayList<Task> taskListCopy = new ArrayList<>(taskList);
+
+        taskListCopy.sort(cmp);
+
+        return taskListCopy;
+
+    }
+
     /**
      * Returns a copy of the list of tasks.
+     * If a sort order is specified, sort the copy before returning.
      *
+     * @param input input string
      */
-    public ArrayList<Task> getTasks() {
-        return new ArrayList<>(this.taskList);
+    public ArrayList<Task> getTasks(String input) {
+        String[] inputWords = input.split(" ");
+
+        if (inputWords.length == 1) {
+            return new ArrayList<>(this.taskList);
+        } else if (inputWords[1].equals("-name")) {
+            return sortTasks(new TimeSorter());
+        } else if (inputWords[1].equals("-time")) {
+            return sortTasks(new NameSorter());
+        } else if (inputWords[1].equals("-done")) {
+            return sortTasks(new DoneSorter());
+        } else {
+            throw new DukeException("I don't understand how you want me to list the tasks");
+        }
     }
 }

--- a/src/main/java/duke/task/Deadline.java
+++ b/src/main/java/duke/task/Deadline.java
@@ -65,11 +65,16 @@ public class Deadline extends Task {
     }
 
     @Override
+    public LocalDate getDate() {
+        return by;
+    }
+
+    @Override
     public String toString() {
         char statusIcon = this.isDone ? 'X' : ' ';
         String timeString = Utility.DATE_MED_FORMATTER.format(this.by);
 
-        return String.format("[%c] duke.task.Deadline: %s (by: %s)",
+        return String.format("[%c] Deadline: %s (by: %s)",
                 statusIcon, this.description, timeString);
     }
 

--- a/src/main/java/duke/task/Event.java
+++ b/src/main/java/duke/task/Event.java
@@ -63,11 +63,16 @@ public class Event extends Task {
     }
 
     @Override
+    public LocalDate getDate() {
+        return on;
+    }
+
+    @Override
     public String toString() {
         char statusIcon = this.isDone ? 'X' : ' ';
         String timeString = Utility.DATE_MED_FORMATTER.format(this.on);
 
-        return String.format("[%c] Task.Event: %s (on: %s)",
+        return String.format("[%c] Event: %s (on: %s)",
                 statusIcon, this.description, timeString);
     }
 

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -1,6 +1,7 @@
 package duke.task;
 
 import java.io.Serializable;
+import java.time.LocalDate;
 
 /**
  * A serializable item that contains a description and a boolean isDone.
@@ -28,6 +29,19 @@ public class Task implements Serializable {
 
     public String getDescription() {
         return this.description;
+    }
+
+    /**
+     * Get date of task. If task has no date associated to it, return the maximum value.
+     *
+     * @return Date of task
+     */
+    public LocalDate getDate() {
+        return LocalDate.MAX;
+    }
+
+    public Boolean isDone() {
+        return isDone;
     }
 
     @Override

--- a/src/main/java/duke/task/ToDo.java
+++ b/src/main/java/duke/task/ToDo.java
@@ -43,7 +43,7 @@ public class ToDo extends Task {
     @Override
     public String toString() {
         char statusIcon = this.isDone ? 'X' : ' ';
-        return String.format("[%c] Task.ToDo: %s", statusIcon, this.description);
+        return String.format("[%c] ToDo: %s", statusIcon, this.description);
     }
 
     @Override

--- a/src/main/java/duke/util/sort/DoneSorter.java
+++ b/src/main/java/duke/util/sort/DoneSorter.java
@@ -1,0 +1,14 @@
+package duke.util.sort;
+
+import java.util.Comparator;
+
+import duke.task.Task;
+
+public class DoneSorter implements Comparator<Task> {
+
+    @Override
+    public int compare(Task t1, Task t2) {
+        return t1.isDone().compareTo(t2.isDone());
+    }
+
+}

--- a/src/main/java/duke/util/sort/NameSorter.java
+++ b/src/main/java/duke/util/sort/NameSorter.java
@@ -1,0 +1,14 @@
+package duke.util.sort;
+
+import java.util.Comparator;
+
+import duke.task.Task;
+
+public class NameSorter implements Comparator<Task> {
+
+    @Override
+    public int compare(Task t1, Task t2) {
+        return t1.getDescription().compareTo(t2.getDescription());
+    }
+
+}

--- a/src/main/java/duke/util/sort/TimeSorter.java
+++ b/src/main/java/duke/util/sort/TimeSorter.java
@@ -1,0 +1,14 @@
+package duke.util.sort;
+
+import java.util.Comparator;
+
+import duke.task.Task;
+
+public class TimeSorter implements Comparator<Task> {
+
+    @Override
+    public int compare(Task t1, Task t2) {
+        return t1.getDate().compareTo(t2.getDate());
+    }
+
+}


### PR DESCRIPTION
When tracking many tasks, users might find it useful to be able to sort tasks.

Let's allow the sorting of tasks alphabetically and chronologically. The commands:
* ```list -name```: sorts and prints the tasks in alphabetical order
* ```list -time```: sorts and prints the tasks in chronological order
* ```list -done```: sorts and prints the tasks, printing undone tasks first

Looking ahead, we should be able to specify multiple sort orders.
e.g. sort -done -time sorts tasks by done status then by time.